### PR TITLE
Add additional pytest marks and dependencies for client-side tox integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+tox.ini
 __pycache__/
 *.py[cod]
 *$py.class

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,5 @@
 pytest
+tox
+black
+coverage
+pytest-cov

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -2,10 +2,13 @@
 Test the hosting services that this application relies on.
 """
 
+import pytest
 import requests
 
+
+@pytest.mark.integration
 def test_extern_status():
-    """ Get hosting status of twitter vid """
+    """Get hosting status of twitter vid"""
 
     HOST = "https://twittervid.com"
     response = requests.head(HOST)

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -1,0 +1,12 @@
+"""
+Test the hosting services that this application relies on.
+"""
+
+import requests
+
+def test_extern_status():
+    """ Get hosting status of twitter vid """
+
+    HOST = "https://twittervid.com"
+    response = requests.head(HOST)
+    assert response.status_code == 200

--- a/tests/test_url_verification.py
+++ b/tests/test_url_verification.py
@@ -1,8 +1,10 @@
 # Assuming all url arguments are standard twitter media url's.
 
+import pytest
 from urllib.parse import urlparse
 
 
+@pytest.mark.unit
 def test_domain_valid():
     """Assert the site is equal to twitter.com"""
     url = "https://twitter.com/TrollFootball/status/1679583964770754560?s=20"

--- a/twitter_downloader.py
+++ b/twitter_downloader.py
@@ -71,12 +71,12 @@ def download_twitter_video(url, file_name):
 
 
 if len(sys.argv) < 2:
-    print('Please provide the Twitter video URL as a command line argument.')
+    print("Please provide the Twitter video URL as a command line argument.")
 else:
     twitter_video_url = sys.argv[1]
     video_id = extract_video_id(twitter_video_url)
     if video_id:
-        file_name = f'{video_id}.mp4'
+        file_name = f"{video_id}.mp4"
         download_twitter_video(twitter_video_url, file_name)
     else:
-        print('Invalid Twitter video URL provided.')
+        print("Invalid Twitter video URL provided.")


### PR DESCRIPTION
* Tox files are now locally recognized and ignored in `.gitignore`
* Additional tests with unit tests and integration marks have been created
* Dependencies to satisfy the above points have been added to dependency files